### PR TITLE
Added Command (Completed the TODO)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ A small Powercord plugin to disable your typing status.
 [Powercord](https://powercord.dev) is a Discord client that's snappy and lightweight, and offers a range of tools and tricks that can be used to interact with the platform.
 
 ## To-Do
-- [ ] Add switch capability to show/hide type notifier (`the use of [p]qtype [--on|--off].`)
+- [x] Add switch capability to show/hide type notifier (`the use of [p]qtype [--on|--off].`)
 
 ### Thanks Aetheryx for the help, always

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports = class SilentType extends Plugin {
         powercord.api.commands.registerCommand({
             command: 'silent-type',
             description: 'Keep your typing to yourself!',
-            usage: '{c} [--on|--off]',
+            usage: '{c} [--on|--off|--status]',
             executor: (args) => ({
                 send: false,
                 result:  this.handler(args)
@@ -16,7 +16,7 @@ module.exports = class SilentType extends Plugin {
     }
      handler(args) {
         args = args.map(a => a.toLowerCase())
-        if (args.includes('--off') && args.includes('--on')) {
+        if (args.includes('--off') && args.includes('--on') || args.includes('--on') && args.includes('status')) {
             return "Oops! Instead of receiving one flag I got both!\nSend only one flag next time"
         } else if (args.includes('--on')) {
             if (this.settings.get('on', true)) {
@@ -32,6 +32,8 @@ module.exports = class SilentType extends Plugin {
             this.settings.set('on')
             this.callRefresh()
             return "Turned Off"
+        } else if (args.includes('--status')) {
+            return `Status: \`${this.settings.get('on') ? "On" : "Off"}\``
         } else {
             return `Incorrect Flags or no flags given\nPlease run \`${powercord.api.commands.prefix}help silent-type\` for command usage`
         }

--- a/index.js
+++ b/index.js
@@ -46,4 +46,3 @@ module.exports = class SilentType extends Plugin {
         typing.startTyping = this.oldStartTyping;
     }
 };
-/* TO-DO Command switch capbility */

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports = class SilentType extends Plugin {
         powercord.api.commands.registerCommand({
             command: 'silent-type',
             description: 'Keep your typing to yourself!',
-            usage: '{c} [--on|--off|--status]',
+            usage: '{c} [--toggle|--status]',
             executor: (args) => ({
                 send: false,
                 result:  this.handler(args)
@@ -16,26 +16,16 @@ module.exports = class SilentType extends Plugin {
     }
      handler(args) {
         args = args.map(a => a.toLowerCase())
-        if (args.includes('--off') && args.includes('--on') || args.includes('--on') && args.includes('status')) {
-            return "Oops! Instead of receiving one flag I got both!\nSend only one flag next time"
-        } else if (args.includes('--on')) {
-            if (this.settings.get('on', true)) {
-                return "I am already turned on\nIf you would like to turn me off use the `--off` flag"
-            }
+        const current = this.settings.get('on')
+        if ((args.includes('--status') || args.includes('status')) && (args.includes('--toggle') || args.includes('toggle'))) {
+            return `${this.handler(['--toggle'])}\n${this.handler(['--status'])}`
+        } else if (args.includes('--toggle') || args.includes('toggle')) {
             this.settings.set('on')
-            this.callRefresh()
-            return "Turned On"
-        } else if (args.includes('--off')) {
-            if (!this.settings.get('on')) {
-                return "I am already turned off\nIf you would like to turn me on use the `--on` flag"
-            }
-            this.settings.set('on')
-            this.callRefresh()
-            return "Turned Off"
-        } else if (args.includes('--status')) {
-            return `Status: \`${this.settings.get('on') ? "On" : "Off"}\``
+            return `Changed from ${current ? "`On`": "`Off`"} to ${!current ? "`On`": "`Off`"}`
+        } else if (args.includes('--status') ||  args.includes('status')) {
+            return `Status: \`${current ? "On" : "Off"}\``
         } else {
-            return `Incorrect Flags or no flags given\nPlease run \`${powercord.api.commands.prefix}help silent-type\` for command usage`
+            return `${args.length > 0 ? `Incorrect flags \`${args.join('| ')}\` given!\n` : `No Flags given!` }\nPlease run \`${powercord.api.commands.prefix}help silent-type\` for command usage`
         }
     }
 

--- a/index.js
+++ b/index.js
@@ -1,11 +1,53 @@
 /* eslint-disable no-empty-function */
 const { Plugin } = require('powercord/entities');
-const { typing } = require('powercord/webpack');
-
 module.exports = class SilentType extends Plugin {
     startPlugin() {
-        this.oldStartTyping = typing.startTyping;
-        typing.startTyping = () => {};
+        powercord.api.commands.registerCommand({
+            command: 'silent-type',
+            description: 'Keep your typing to yourself!',
+            usage: '{c} [--on|--off]',
+            executor: (args) => ({
+                send: false,
+                result:  this.handler(args)
+            })
+        })
+        // Magic
+        this.callRefresh()
+    }
+     handler(args) {
+        args = args.map(a => a.toLowerCase())
+        if (args.includes('--off') && args.includes('--on')) {
+            return "Oops! Instead of receiving one flag I got both!\nSend only one flag next time"
+        } else if (args.includes('--on')) {
+            if (this.settings.get('on', true)) {
+                return "I am already turned on\nIf you would like to turn me off use the `--off` flag"
+            }
+            this.settings.set('on')
+            this.callRefresh()
+            return "Turned On"
+        } else if (args.includes('--off')) {
+            if (!this.settings.get('on')) {
+                return "I am already turned off\nIf you would like to turn me on use the `--on` flag"
+            }
+            this.settings.set('on')
+            this.callRefresh()
+            return "Turned Off"
+        } else {
+            return `Incorrect Flags or no flags given\nPlease run \`${powercord.api.commands.prefix}help silent-type\` for command usage`
+        }
+    }
+
+    callRefresh() {
+        try {
+            const { typing } = require('powercord/webpack');
+            typing.startTyping = (startTyping => (channel) => setImmediate(() => {
+                const on = this.settings.get('on')
+                if (!on) {
+                    startTyping(channel)
+                }
+            }))(this.oldStartTyping = typing.startTyping)
+        } catch (e) {
+        }
     }
 
     pluginWillUnload() {


### PR DESCRIPTION
Added a command that allows you to toggle `--on` and `--off` using `.silent-type`
It works right away too! I will be willing to make this into settings but you can already turn commands off and on using powercords `Plugins > Silent Type > Toggle`

Edit: would also like to clarify that the "2 people" were me. I just messed up a new github install